### PR TITLE
Feat/wb2 1337 Add Routing for Note Modal

### DIFF
--- a/frontend/src/components/note-modal/index.tsx
+++ b/frontend/src/components/note-modal/index.tsx
@@ -1,52 +1,67 @@
 import { Button, Modal } from "@edifice-ui/react";
+import { odeServices } from "edifice-ts-client";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import {
+  LoaderFunctionArgs,
+  useLoaderData,
+  useNavigate,
+} from "react-router-dom";
 
 import { NoteProps } from "~/services/api";
 
-export interface NoteModalProps {
-  isOpen: boolean;
-  setIsOpen: (bool: boolean) => void;
+export async function noteLoader({ params }: LoaderFunctionArgs) {
+  const { id, idnote } = params;
 
-  /** Note data. */
-  data: NoteProps | undefined;
+  const note = await odeServices
+    .http()
+    .get<NoteProps>(`/collaborativewall/${id}/note/${idnote}`);
+
+  if (!note) {
+    throw new Response("", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return note;
 }
 
-export default function NoteModal({
-  isOpen,
-  setIsOpen,
-  data,
-}: NoteModalProps): JSX.Element | null {
+export const NoteModal = () => {
   const { t } = useTranslation();
+  const data = useLoaderData() as NoteProps;
+  const navigate = useNavigate();
 
-  return isOpen
-    ? createPortal(
-        <Modal
-          id="NoteModal"
-          onModalClose={() => setIsOpen(false)}
-          size="md"
-          isOpen={isOpen}
-          focusId=""
-        >
-          <Modal.Header onModalClose={() => setIsOpen(false)}>
-            {t("Note")}
-          </Modal.Header>
-          <Modal.Subtitle>{data?.owner?.displayName}</Modal.Subtitle>
-          <Modal.Body>
-            <p>{data?.content}</p>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button
-              type="button"
-              color="primary"
-              variant="filled"
-              onClick={() => setIsOpen(false)}
-            >
-              {t("Fermer")}
-            </Button>
-          </Modal.Footer>
-        </Modal>,
-        document.getElementById("portal") as HTMLElement,
-      )
-    : null;
-}
+  return data ? (
+    createPortal(
+      <Modal
+        id="NoteModal"
+        onModalClose={() => navigate("..")}
+        size="md"
+        isOpen={true}
+        focusId=""
+      >
+        <Modal.Header onModalClose={() => navigate("..")}>
+          {t("Note")}
+        </Modal.Header>
+        <Modal.Subtitle>{data.owner?.displayName}</Modal.Subtitle>
+        <Modal.Body>
+          <p>{data.content}</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="button"
+            color="primary"
+            variant="filled"
+            onClick={() => navigate("..")}
+          >
+            {t("Fermer")}
+          </Button>
+        </Modal.Footer>
+      </Modal>,
+      document.getElementById("portal") as HTMLElement,
+    )
+  ) : (
+    <p>{t("collaborativewall.note.notfound")}</p>
+  );
+};

--- a/frontend/src/components/note-modal/index.tsx
+++ b/frontend/src/components/note-modal/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Modal } from "@edifice-ui/react";
-import { odeServices } from "edifice-ts-client";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -8,14 +7,19 @@ import {
   useNavigate,
 } from "react-router-dom";
 
-import { NoteProps } from "~/services/api";
+import { NoteProps, getNote } from "~/services/api";
 
 export async function noteLoader({ params }: LoaderFunctionArgs) {
   const { id, idnote } = params;
 
-  const note = await odeServices
-    .http()
-    .get<NoteProps>(`/collaborativewall/${id}/note/${idnote}`);
+  if (!id || !idnote) {
+    throw new Response("", {
+      status: 404,
+      statusText: "Wall id or Note id is null",
+    });
+  }
+
+  const note = await getNote(id, idnote);
 
   if (!note) {
     throw new Response("", {

--- a/frontend/src/components/note/index.tsx
+++ b/frontend/src/components/note/index.tsx
@@ -41,6 +41,10 @@ export const Note = ({
 
   const defaultImage = "/img/cloud.png";
 
+  const handleClick = (noteId: string): void => {
+    onClick(noteId);
+  };
+
   return (
     <div
       ref={setNodeRef}
@@ -61,7 +65,7 @@ export const Note = ({
       <Card
         className={`note ${isDragging && "is-dragging"} ${canMoveNote && !isDragging && "is-grab"}`}
         isSelectable={false}
-        onClick={() => onClick(note._id)}
+        onClick={() => handleClick(note._id)}
       >
         <Card.Body>
           {/* Modifier l'image lorsqu'on récupéreré une image */}

--- a/frontend/src/components/note/index.tsx
+++ b/frontend/src/components/note/index.tsx
@@ -7,10 +7,10 @@ import { useWhiteboard } from "~/store";
 
 export const Note = ({
   note,
-  onNoteClick,
+  onClick,
 }: {
   note: NoteProps;
-  onNoteClick: (note: NoteProps) => void;
+  onClick: (id: string) => void;
 }) => {
   const { zoom, canMoveNote, isBoardDragging } = useWhiteboard(
     useShallow((state) => ({
@@ -61,7 +61,7 @@ export const Note = ({
       <Card
         className={`note ${isDragging && "is-dragging"} ${canMoveNote && !isDragging && "is-grab"}`}
         isSelectable={false}
-        onClick={() => onNoteClick(note)}
+        onClick={() => onClick(note._id)}
       >
         <Card.Body>
           {/* Modifier l'image lorsqu'on récupéreré une image */}

--- a/frontend/src/routes/collaborative-wall/index.tsx
+++ b/frontend/src/routes/collaborative-wall/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useState } from "react";
+import { lazy, useEffect, useState } from "react";
 
 import {
   DndContext,
@@ -11,17 +11,16 @@ import {
   Active,
 } from "@dnd-kit/core";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
-import {
-  AppHeader,
-  Breadcrumb,
-  Button,
-  LoadingScreen,
-  useOdeClient,
-} from "@edifice-ui/react";
+import { AppHeader, Breadcrumb, Button, useOdeClient } from "@edifice-ui/react";
 import { IWebApp, odeServices } from "edifice-ts-client";
 // @ts-ignore
 import { useTranslation } from "react-i18next";
-import { LoaderFunctionArgs, useLoaderData } from "react-router-dom";
+import {
+  LoaderFunctionArgs,
+  Outlet,
+  useLoaderData,
+  useNavigate,
+} from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 
 import { DescriptionWall } from "~/components/description-wall";
@@ -33,8 +32,6 @@ import { useWhiteboard } from "~/store";
 const DescriptionModal = lazy(
   async () => await import("~/components/description-modal"),
 );
-
-const NoteModal = lazy(async () => await import("~/components/note-modal"));
 
 const activationConstraint = {
   delay: 250,
@@ -76,6 +73,7 @@ export const CollaborativeWall = () => {
 
   const { t } = useTranslation();
   const data = useLoaderData() as CollaborativeWallProps;
+  const navigate = useNavigate();
 
   const { setNotes, notes, zoom } = useWhiteboard(
     useShallow((state) => ({
@@ -86,8 +84,6 @@ export const CollaborativeWall = () => {
   );
   // const [openShare, setOpenShare] = useState(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [showNoteModal, setShowNoteModal] = useState<boolean>(false);
-  const [clickedNoteData, setClickedNoteData] = useState<NoteProps>();
 
   // const handleCloseModal = () => setOpenShare(false);
 
@@ -120,11 +116,6 @@ export const CollaborativeWall = () => {
   }) => {
     const activeId = active.id as string;
     updateNotePosition({ activeId, x: delta.x / zoom, y: delta.y / zoom });
-  };
-
-  const handleNoteClick = (note: NoteProps) => {
-    setClickedNoteData(note);
-    setShowNoteModal(true);
   };
 
   return data ? (
@@ -164,27 +155,21 @@ export const CollaborativeWall = () => {
                     title: `title ${i}`,
                     zIndex: note.zIndex ?? 1,
                   }}
-                  onNoteClick={handleNoteClick}
+                  onClick={(id) => navigate(`note/${id}`)}
                 />
               );
             })}
           </DndContext>
         </WhiteboardWrapper>
+
+        <Outlet />
+
         {data?.description && (
           <DescriptionModal
             isOpen={isOpen}
             setIsOpen={setIsOpen}
             description={data?.description}
           />
-        )}
-        {showNoteModal && (
-          <Suspense fallback={<LoadingScreen />}>
-            <NoteModal
-              isOpen={showNoteModal}
-              setIsOpen={setShowNoteModal}
-              data={clickedNoteData}
-            />
-          </Suspense>
         )}
       </div>
       {/* <Suspense fallback={<LoadingScreen />}>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,10 +1,10 @@
-import { createBrowserRouter } from "react-router-dom";
+import { RouteObject, createBrowserRouter } from "react-router-dom";
 
 import ErrorPage from "~/components/page-error";
 
 import "~/styles/index.css";
 
-const routes = [
+const routes: RouteObject[] = [
   {
     path: "id/:id",
     async lazy() {
@@ -16,6 +16,17 @@ const routes = [
         Component: CollaborativeWall,
       };
     },
+    children: [
+      {
+        path: "note/:idnote",
+        async lazy() {
+          const { noteLoader, NoteModal } = await import(
+            "../components/note-modal"
+          );
+          return { loader: noteLoader, Component: NoteModal };
+        },
+      },
+    ],
     errorElement: <ErrorPage />,
   },
 ];

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -31,11 +31,25 @@ export interface NoteProps {
 }
 
 /**
+ * getNote API
+ * @param idWall wall id
+ * @param idNote note id
+ * @returns note
+ */
+export const getNote = async (
+  idWall: string,
+  idNote: string,
+): Promise<NoteProps> => {
+  return await odeServices
+    .http()
+    .get<NoteProps>(`/collaborativewall/${idWall}/note/${idNote}`);
+};
+
+/**
  * getNotes API
  * @param id, resource ID
  * @returns notes
  */
-
 export const getNotes = async (id: string) => {
   const notes = await odeServices
     .http()


### PR DESCRIPTION
Add route `note/:idnote` as child of main route`id/:id` to show Note Modal.
Data is loaded via a route loader executing a http request to the new API that returns note data by given idnote.