### PR TITLE
feat: #WB2-1441, share modal + useHasRights hook

### DIFF
--- a/frontend/src/hooks/useHasRights.ts
+++ b/frontend/src/hooks/useHasRights.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { type RightRole, odeServices, ResourceRight } from "edifice-ts-client";
+
+export interface IObjectWithRights {
+  rights: string[];
+}
+
+type Roles = RightRole | RightRole[];
+
+interface UseHasRightsProps {
+  roles: Roles;
+  rights:
+    | string
+    | string[]
+    | IObjectWithRights
+    | IObjectWithRights[]
+    | undefined;
+}
+
+export function useHasRights({ roles, rights }: UseHasRightsProps) {
+  const [state, setState] = useState<boolean>(false);
+
+  const convertToArray = (rights: string | string[]) =>
+    rights instanceof Array ? rights : [rights];
+
+  const checkRights = useCallback(
+    async (roles: Roles, rights: string | string[]) => {
+      const safeRights = convertToArray(rights);
+      const can = Array.isArray(roles)
+        ? await odeServices
+            .rights()
+            .sessionHasAtLeastOneResourceRight(roles, safeRights)
+        : await odeServices.rights().sessionHasResourceRight(roles, safeRights);
+      setState(can);
+    },
+    [],
+  );
+
+  const checkRightForMultipleResources = useCallback(
+    async (roles: Roles, rights: ResourceRight[][] | string[][]) => {
+      const can = Array.isArray(roles)
+        ? await odeServices
+            .rights()
+            .sessionHasAtLeastOneResourceRightForEachList(roles, rights)
+        : await odeServices
+            .rights()
+            .sessionHasResourceRightForEachList(roles, rights);
+      setState(can);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    (async () => {
+      if (roles === undefined) {
+        setState(true);
+        return;
+      }
+      if (Array.isArray(rights)) {
+        if (rights.length > 0) {
+          if (typeof rights[0] === "string") {
+            await checkRights(roles, rights as string[]);
+          } else {
+            const rightsArray = (rights as IObjectWithRights[]).map(
+              (right) => right.rights,
+            );
+            await checkRightForMultipleResources(roles, rightsArray);
+          }
+        } else {
+          setState(false);
+        }
+      } else {
+        if (typeof rights === "string") {
+          await checkRights(roles, rights);
+        } else if (rights) {
+          await checkRights(roles, rights.rights);
+        }
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return state;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React /* , { StrictMode } */ from "react";
 
 import "./i18n";
 import { OdeClientProvider, ThemeProvider } from "@edifice-ui/react";
@@ -16,14 +16,14 @@ import { router } from "./routes";
 const rootElement = document.getElementById("root");
 const root = createRoot(rootElement!);
 
-if (process.env.NODE_ENV !== "production") {
+if (import.meta.env.DEV) {
   // eslint-disable-next-line global-require
   import("@axe-core/react").then((axe) => {
     axe.default(React, root, 1000);
   });
 }
 
-if (process.env.NODE_ENV !== "production") {
+if (import.meta.env.DEV) {
   import("edifice-bootstrap/dist/index.css");
 }
 
@@ -37,11 +37,13 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
+      // staleTime: 1000 * 60 * 5,
     },
   },
 });
 
 root.render(
+  // <StrictMode>
   <QueryClientProvider client={queryClient}>
     <OdeClientProvider
       params={{
@@ -54,4 +56,5 @@ root.render(
     </OdeClientProvider>
     <ReactQueryDevtools initialIsOpen={false} />
   </QueryClientProvider>,
+  // </StrictMode>,
 );

--- a/frontend/src/models/wall.ts
+++ b/frontend/src/models/wall.ts
@@ -9,5 +9,6 @@ export interface CollaborativeWallProps {
     displayName: string;
   };
   shared: string[];
+  rights: string[];
   description?: string;
 }

--- a/frontend/src/routes/collaborative-wall/index.tsx
+++ b/frontend/src/routes/collaborative-wall/index.tsx
@@ -28,6 +28,7 @@ import { EmptyScreenError } from "~/components/emptyscreen-error";
 import { Note } from "~/components/note";
 import { WhiteboardWrapper } from "~/components/whiteboard-wrapper";
 import { useDndKit } from "~/hooks/useDndKit";
+import { useHasRights } from "~/hooks/useHasRights";
 import { useMoveNote } from "~/hooks/useMoveNote";
 import { NoteProps } from "~/models/notes";
 import { CollaborativeWallProps } from "~/models/wall";
@@ -119,10 +120,17 @@ export const CollaborativeWall = () => {
 
   const { updatedNote, handleOnDragEnd } = useMoveNote({ zoom, notes });
 
+  const canShare = useHasRights({
+    roles: "creator",
+    rights: wall?.rights,
+  });
+
   useEffect(() => {
     if (query) setIsMobile(query);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
+
+  console.count("Collab");
 
   if (isWallLoading && isNotesLoading) return <LoadingScreen />;
 
@@ -134,13 +142,13 @@ export const CollaborativeWall = () => {
         <AppHeader
           isFullscreen
           style={{ position: "sticky" }}
-          render={() => (
-            <>
+          render={() =>
+            canShare ? (
               <Button variant="filled" onClick={() => setOpenShareModal(true)}>
                 {t("share")}
               </Button>
-            </>
-          )}
+            ) : null
+          }
         >
           <Breadcrumb app={currentApp as IWebApp} name={wall?.name} />
         </AppHeader>


### PR DESCRIPTION
- refacto hook `useAccessControl` en `useHasRights`
- utilisation pour checker le droit de la modale de partage

### hook

[https://github.com/OPEN-ENT-NG/collaborative-wall/blob/80691ca0db8c28e7b8995affa3492ead0a7b9ae0/frontend/src/hooks/useHasRights.ts](hook)

### utilisation

- accepte un role ou plusieurs (string[])
- accepte les droits de la ressource avec le tableau `rights`

```
const canShare = useHasRights({
    roles: "creator",
    rights: wall?.rights,
  });
```

j'externaliserai le hook une fois qu'on sera repassé sur toute la gestion des droits