### PR TITLE
feat: #WB2-1494, add rights to move note

### DIFF
--- a/frontend/src/components/background-modal/index.tsx
+++ b/frontend/src/components/background-modal/index.tsx
@@ -32,6 +32,7 @@ export default function BackgroundModal({
   const { t } = useTranslation();
 
   const [backgroundValue, setBackgroundValue] = useState<string>("");
+
   const updateWall = useUpdateWall();
 
   const handleClose = () => setIsOpen(false);
@@ -42,7 +43,7 @@ export default function BackgroundModal({
       description: wall.description,
       name: wall.name,
     };
-    updateWall.mutateAsync({ wallId: wall._id, newWall });
+    updateWall.mutate({ wallId: wall._id, newWall });
   };
 
   return isOpen
@@ -72,7 +73,7 @@ export default function BackgroundModal({
               </Heading>
               <Grid>
                 {backgroundImages.map((image) => (
-                  <Grid.Col sm="2">
+                  <Grid.Col sm="2" key={image}>
                     <Card
                       isClickable={true}
                       isSelectable={false}

--- a/frontend/src/components/note/index.tsx
+++ b/frontend/src/components/note/index.tsx
@@ -3,6 +3,7 @@ import { Card } from "@edifice-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Editor, EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import clsx from "clsx";
 import { useShallow } from "zustand/react/shallow";
 
 import { ShowMediaType } from "../show-media-type";
@@ -16,17 +17,16 @@ export const Note = ({
   onClick,
 }: {
   note: NoteProps;
-  disabled: () => boolean;
+  disabled: boolean;
   onClick?: (id: string) => void;
 }) => {
   const queryClient = useQueryClient();
   const deleteNote = useDeleteNote();
 
-  const { zoom, canMoveNote, isBoardDragging } = useWhiteboard(
+  const { zoom } = useWhiteboard(
     useShallow((state) => ({
       zoom: state.zoom,
-      canMoveNote: state.canMoveNote,
-      isBoardDragging: state.isDragging,
+      isDragging: state.isDragging,
     })),
   );
 
@@ -46,10 +46,10 @@ export const Note = ({
     position: "absolute",
     borderRadius: "0.8rem",
     zIndex: isDragging ? 200 : note.zIndex,
-    userSelect: (isDragging || isBoardDragging) && "none",
+    userSelect: isDragging && "none",
     top: (transform?.y ?? 0) / zoom,
     left: (transform?.x ?? 0) / zoom,
-    cursor: canMoveNote ? (isDragging ? "grabbing" : "grab") : "default",
+    // cursor: canMoveNote ? (isDragging ? "grabbing" : "grab") : "default",
     boxShadow: isDragging
       ? "-1px 0 15px 0 rgba(34, 33, 81, 0.01), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)"
       : "0 2px 6px 0px rgba(0, 0, 0, 0.15)",
@@ -62,6 +62,11 @@ export const Note = ({
   };
 
   const { setHistory } = useHistoryStore();
+
+  const classes = clsx("note", {
+    "is-dragging": isDragging,
+    "is-grab": disabled && !isDragging,
+  });
 
   return (
     <div
@@ -102,7 +107,7 @@ export const Note = ({
         delete
       </button>
       <Card
-        className={`note ${isDragging && "is-dragging"} ${canMoveNote && !isDragging && "is-grab"}`}
+        className={classes}
         isSelectable={false}
         onClick={() => handleClick(note._id)}
       >

--- a/frontend/src/components/whiteboard-wrapper/index.tsx
+++ b/frontend/src/components/whiteboard-wrapper/index.tsx
@@ -1,15 +1,12 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
 import { TransformWrapper } from "react-zoom-pan-pinch";
 import { useShallow } from "zustand/react/shallow";
 
 import { ToolbarWrapper } from "../toolbar";
 import { WhiteboardComponent } from "../whiteboard-component";
 import { zoomConfig } from "~/config/init-config";
-import { useHasRights } from "~/hooks/useHasRights";
-import { wallQueryOptions } from "~/services/queries";
+import { useAccess } from "~/hooks/useAccess";
 import { useWhiteboard } from "~/store";
 import { calculateMinScale } from "~/utils/calculMinScale";
 
@@ -26,8 +23,6 @@ export const WhiteboardWrapper = ({ children }: { children: ReactNode }) => {
 
   const [minScale, setMinScale] = useState(1);
 
-  const params = useParams();
-
   const ref = useRef<any>(null);
 
   const handleScaleChange = (event: any) => {
@@ -38,15 +33,7 @@ export const WhiteboardWrapper = ({ children }: { children: ReactNode }) => {
     setZoom(event.instance.transformState.scale);
   };
 
-  const { data: wall } = useQuery({
-    queryKey: wallQueryOptions(params.wallId as string).queryKey,
-    queryFn: wallQueryOptions(params.wallId as string).queryFn,
-  });
-
-  const canUpdate = useHasRights({
-    roles: ["creator"],
-    rights: wall?.rights,
-  });
+  const { isCreator } = useAccess();
 
   useEffect(() => {
     const handleResize = () => {
@@ -58,6 +45,7 @@ export const WhiteboardWrapper = ({ children }: { children: ReactNode }) => {
     handleResize();
 
     return () => window.removeEventListener("resize", handleResize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [window.innerHeight, window.innerWidth]);
 
   return (
@@ -77,14 +65,14 @@ export const WhiteboardWrapper = ({ children }: { children: ReactNode }) => {
               children={children}
               zoomIn={zoomIn}
               zoomOut={zoomOut}
-              canUpdate={canUpdate}
+              canUpdate={isCreator}
             />
             {!isMobile && (
               <ToolbarWrapper
                 zoomIn={zoomIn}
                 zoomOut={zoomOut}
                 setTransform={setTransform}
-                canUpdate={canUpdate}
+                canUpdate={isCreator}
               />
             )}
           </div>

--- a/frontend/src/features/app-actions/index.tsx
+++ b/frontend/src/features/app-actions/index.tsx
@@ -1,0 +1,61 @@
+import { RefAttributes } from "react";
+
+import { Options, Landscape } from "@edifice-ui/icons";
+import {
+  Button,
+  Dropdown,
+  IconButtonProps,
+  IconButton,
+} from "@edifice-ui/react";
+import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
+
+import { useAccess } from "~/hooks/useAccess";
+import { useWhiteboard } from "~/store";
+
+export const AppActions = () => {
+  const { isCreator } = useAccess();
+  const { t } = useTranslation();
+
+  const { setOpenShareModal, setIsOpenBackgroundModal } = useWhiteboard(
+    useShallow((state) => ({
+      setOpenShareModal: state.setOpenShareModal,
+      setIsOpenBackgroundModal: state.setIsOpenBackgroundModal,
+    })),
+  );
+
+  return isCreator ? (
+    <>
+      <Button variant="filled" onClick={() => setOpenShareModal(true)}>
+        {t("share")}
+      </Button>
+      <Dropdown>
+        {(
+          triggerProps: JSX.IntrinsicAttributes &
+            Omit<IconButtonProps, "ref"> &
+            RefAttributes<HTMLButtonElement>,
+        ) => (
+          <>
+            <IconButton
+              {...triggerProps}
+              type="button"
+              aria-label="label"
+              color="primary"
+              variant="outline"
+              icon={<Options />}
+            />
+
+            <Dropdown.Menu>
+              <Dropdown.Item
+                icon={<Landscape />}
+                onClick={() => setIsOpenBackgroundModal(true)}
+              >
+                {t("collaborativewall.modal.background")}
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </>
+        )}
+      </Dropdown>
+    </>
+  ) : null;
+};

--- a/frontend/src/features/history/hooks/useHistory.ts
+++ b/frontend/src/features/history/hooks/useHistory.ts
@@ -33,7 +33,6 @@ export const useHistory = () => {
   };
 
   const createAction = async (action: NewState) => {
-    console.log({ action });
     const response = await createNote.mutateAsync({
       color: action.item.color,
       content: action.item.content,

--- a/frontend/src/hooks/useAccess.ts
+++ b/frontend/src/hooks/useAccess.ts
@@ -1,0 +1,46 @@
+import { useUser } from "@edifice-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+
+import { useHasRights } from "./useHasRights";
+import { NoteProps } from "~/models/notes";
+import { wallQueryOptions } from "~/services/queries";
+
+export const useAccess = () => {
+  const params = useParams();
+
+  const { data: wall } = useQuery({
+    queryKey: wallQueryOptions(params.wallId as string).queryKey,
+    queryFn: wallQueryOptions(params.wallId as string).queryFn,
+  });
+
+  const { user } = useUser();
+
+  const isCreator = useHasRights({
+    roles: "creator",
+    rights: wall?.rights,
+  });
+
+  const isManager = useHasRights({
+    roles: ["manager"],
+    rights: wall?.rights,
+  });
+
+  const isContributor = useHasRights({
+    roles: "contrib",
+    rights: wall?.rights,
+  });
+
+  const isReader = useHasRights({
+    roles: "read",
+    rights: wall?.rights,
+  });
+
+  const hasRightsToMoveNote = (note: NoteProps) => {
+    return ((isCreator && isManager) ||
+      (isContributor &&
+        note?.owner?.userId.includes(user?.userId as string))) as boolean;
+  };
+
+  return { isCreator, isManager, isContributor, isReader, hasRightsToMoveNote };
+};

--- a/frontend/src/models/store.ts
+++ b/frontend/src/models/store.ts
@@ -66,6 +66,7 @@ export type State = {
   openShareModal: boolean;
   openCreateModal: boolean;
   openDescriptionModal: boolean;
+  openBackgroundModal: boolean;
   positionViewport: Offset;
 };
 
@@ -79,5 +80,6 @@ export type Action = {
   setOpenShareModal: (value: boolean) => void;
   setOpenCreateModal: (value: boolean) => void;
   setOpenDescriptionModal: (value: boolean) => void;
+  setIsOpenBackgroundModal: (value: boolean) => void;
   setPositionViewport: (value: { x: number; y: number }) => void;
 };

--- a/frontend/src/store/whiteboard.store.ts
+++ b/frontend/src/store/whiteboard.store.ts
@@ -15,6 +15,7 @@ const initialState = {
   openShareModal: false,
   openCreateModal: false,
   openDescriptionModal: false,
+  openBackgroundModal: false,
   positionViewport: {
     x: 0,
     y: 0,
@@ -39,6 +40,8 @@ export const useWhiteboard = create<State & Action>((set) => ({
   setOpenCreateModal: (value: boolean) => set({ openCreateModal: value }),
   setOpenDescriptionModal: (value: boolean) =>
     set({ openDescriptionModal: value }),
+  setIsOpenBackgroundModal: (value: boolean) =>
+    set({ openBackgroundModal: value }),
   setPositionViewport: (value: { x: number; y: number }) =>
     set({ positionViewport: value }),
 }));


### PR DESCRIPTION
# Description

- Add `useAccess` hook to re-export is a user is a creator, contributor, reader or manager
- Add method to check if the user can move a note
- Changed current rights with new hook