### PR TITLE
fix: #WB2-1487, fix attachment text truncate in Note Modal

### DIFF
--- a/frontend/src/components/show-media-type/index.tsx
+++ b/frontend/src/components/show-media-type/index.tsx
@@ -18,10 +18,11 @@ export const ShowMediaType = ({
 }: ShowMediaTypeProps) => {
   const { t } = useTranslation();
 
-  const mediaClasses = clsx("media-center", {
+  const mediaClasses = clsx({
+    "media-center": readonly,
     "d-block": readonly,
-    "py-48": !readonly,
-    "px-12": !readonly,
+    "px-64": !readonly,
+    "py-32": !readonly,
   });
 
   switch (media.type) {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -13,7 +13,7 @@
 
 #NoteModal .multimedia-section {
   width: 100%;
-  min-height: 178px;
+  min-height: 120px;
   border-radius: 16px;
   border: 1px solid #f2f2f2;
   gap: 8px;


### PR DESCRIPTION
Dans la Modal de Note la classe CSS `media-center` met un `display: flex` qui "casse" le text-truncate de l'Attachment. 

J'ai donc mis la classe media-center uniquement sur la vignette et non la modale de note. 

J'ai réajusté également les paddings pour coller à la maquette