### PR TITLE
fix: #WB2-11, fix Read and Update Note Modal buttons

### DIFF
--- a/backend/src/main/resources/i18n/fr.json
+++ b/backend/src/main/resources/i18n/fr.json
@@ -36,6 +36,7 @@
   "collaborativewall.modal.close": "Fermer",
   "collaborativewall.modal.cancel": "Annuler",
   "collaborativewall.modal.modify": "Modifier",
+  "collaborativewall.modal.save": "Enregistrer",
   "collaborativewall.modal.add": "Ajouter",
   "collaborativewall.modal.create": "Nouvelle Note",
   "collaborativewall.note.notfound": "Note introuvable.",

--- a/frontend/src/components/update-note-modal/index.tsx
+++ b/frontend/src/components/update-note-modal/index.tsx
@@ -183,34 +183,58 @@ export const UpdateNoteModal = () => {
           />
         </Modal.Body>
         <Modal.Footer>
+          {editionMode === "read" && !hasRightsToUpdateNote(data) && (
+            <>
+              <Button
+                type="button"
+                color="primary"
+                variant="filled"
+                onClick={handleNavigateBack}
+              >
+                {t("collaborativewall.modal.close")}
+              </Button>
+            </>
+          )}
           {editionMode === "read" && hasRightsToUpdateNote(data) && (
-            <Button
-              type="button"
-              color="primary"
-              variant="outline"
-              onClick={handleNavigateToEditMode}
-            >
-              {t("edit")}
-            </Button>
+            <>
+              <Button
+                type="button"
+                color="tertiary"
+                variant="ghost"
+                onClick={handleNavigateBack}
+              >
+                {t("collaborativewall.modal.close")}
+              </Button>
+              <Button
+                type="button"
+                color="primary"
+                variant="filled"
+                onClick={handleNavigateToEditMode}
+              >
+                {t("collaborativewall.modal.modify")}
+              </Button>
+            </>
           )}
           {editionMode === "edit" && (
-            <Button
-              type="button"
-              color="tertiary"
-              variant="ghost"
-              onClick={handleNavigateBack}
-            >
-              {t("cancel")}
-            </Button>
+            <>
+              <Button
+                type="button"
+                color="tertiary"
+                variant="ghost"
+                onClick={handleNavigateBack}
+              >
+                {t("collaborativewall.modal.cancel")}
+              </Button>
+              <Button
+                type="button"
+                color="primary"
+                variant="filled"
+                onClick={handleSaveNote}
+              >
+                {t("collaborativewall.modal.save")}
+              </Button>
+            </>
           )}
-          <Button
-            type="button"
-            color="primary"
-            variant="filled"
-            onClick={handleSaveNote}
-          >
-            {editionMode === "edit" ? t("edit") : t("close")}
-          </Button>
         </Modal.Footer>
       </Modal>,
       document.getElementById("portal") as HTMLElement,


### PR DESCRIPTION
Update Buttons label and position in Update Note Modal:

En mode consultation de la note :

« Modifier » devient l’action principale -> il passe à droite en primary
« Fermer » passe à gauche en tertiary

En mode Modification de la note :

Changer le texte de « Modifier » pour « Enregistrer »