### PR TITLE
fix: #WB2-1583, add useHotKeys from Mantine to fix Space keypress issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "@edifice-ui/editor": "develop-pedago",
     "@edifice-ui/icons": "develop-pedago",
     "@edifice-ui/react": "develop-pedago",
+    "@mantine/hooks": "7.7.1",
     "@react-spring/web": "9.7.3",
     "@tanstack/react-query": "5.18.0",
     "@tiptap/pm": "2.0.3",

--- a/frontend/src/components/whiteboard-component/index.tsx
+++ b/frontend/src/components/whiteboard-component/index.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode } from "react";
 
+import { useHotkeys } from "@mantine/hooks";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { TransformComponent } from "react-zoom-pan-pinch";
@@ -46,59 +47,27 @@ export const WhiteboardComponent = ({
     })),
   );
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    /* This is just a test but create a note with cmd + k */
-    if (event.metaKey && event.key === "k") {
-      //createNote();
-    }
-
-    /* Enable moveboard when space is pressed */
-    if (event.code === "Space") {
-      event.preventDefault();
-      setCanMoveNote(false);
-    }
-  };
-
-  /* Disable moveboard when space is released */
-  const handleKeyUp = (event: KeyboardEvent) => {
-    if (event.code === "Space") {
-      event.preventDefault();
-      setCanMoveNote(true);
-    }
-    if (canMoveNote && event.key === "v") {
-      setCanMoveNote(true);
-      setCanMoveBoard(false);
-    }
-    if (event.key === "h") {
-      setCanMoveBoard(true);
-      setCanMoveNote(false);
-    }
-
-    if (event.key === "-") {
-      zoomOut(zoomConfig.SCALE_ZOOM);
-    }
-    if (event.key === "=" || event.key === "+") {
-      zoomIn(zoomConfig.SCALE_ZOOM);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("keyup", handleKeyUp);
-
-    return () => {
-      window.removeEventListener("keyup", handleKeyUp);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // hot keys for moving and zooming board
+  useHotkeys([
+    ["Space", () => setCanMoveNote(!canMoveNote)],
+    [
+      "V",
+      () => {
+        setCanMoveNote(true);
+        setCanMoveBoard(false);
+      },
+    ],
+    [
+      "H",
+      () => {
+        setCanMoveNote(false);
+        setCanMoveBoard(true);
+      },
+    ],
+    ["-", () => zoomOut(zoomConfig.SCALE_ZOOM)],
+    ["+", () => zoomIn(zoomConfig.SCALE_ZOOM)],
+    ["=", () => zoomIn(zoomConfig.SCALE_ZOOM)],
+  ]);
 
   return (
     <>

--- a/frontend/src/features/note-modal/hooks/useNoteModal.ts
+++ b/frontend/src/features/note-modal/hooks/useNoteModal.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react";
+import { RefObject } from "react";
 
 import { EditorRef } from "@edifice-ui/editor";
 import { useQueryClient } from "@tanstack/react-query";
@@ -39,38 +39,6 @@ export const useNoteModal = (
       zoom: state.zoom,
     })),
   );
-
-  // There is a window event listener on Space, "-", "=", "+" keys to move, unzoom, zoom the whiteboard respectively,
-  // So we need to stop these keys propagation in order to make these keys work in Editor.
-  useEffect(() => {
-    const stopPropagation = (event: KeyboardEvent) => {
-      if (
-        event.code === "Space" ||
-        event.key === "-" ||
-        event.key === "=" ||
-        event.key === "+"
-      ) {
-        event.stopPropagation();
-      }
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      stopPropagation(event);
-    };
-
-    const handleKeyUp = (event: KeyboardEvent) => {
-      stopPropagation(event);
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("keyup", handleKeyUp);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("keyup", handleKeyUp);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const isReadMode = () => editionMode === "read";
   const isEditMode = () => editionMode === "edit";


### PR DESCRIPTION
Utilisation du hook useHotKeys de la librairie Mantine ([use-hotkeys | Mantine](https://mantine.dev/hooks/use-hotkeys/) ) qui permet d’ignorer les events listener pour les éléments input, textarea et select.

Retrait du fix fait dans la modale de Modification d’une note car n’est plus nécessaire grâce au hook.