### PR TITLE
fix: #WB2-1562, use Editor with full extensions and save content in html

### DIFF
--- a/frontend/src/components/note/index.tsx
+++ b/frontend/src/components/note/index.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useDraggable } from "@dnd-kit/core";
+import { Editor } from "@edifice-ui/editor";
 import { Card } from "@edifice-ui/react";
-import { Editor, EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 import clsx from "clsx";
 import { useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
@@ -39,25 +38,6 @@ export const Note = ({
       id: note._id,
       disabled: !canMoveNote || !disabled,
     });
-
-  const editor: Editor | null = useEditor({
-    extensions: [
-      StarterKit.configure({
-        paragraph: {
-          HTMLAttributes: {
-            class: `card-text small text-break text-truncate ${note.media ? "text-truncate-8" : "text-truncate-12"}`,
-          },
-        },
-      }),
-    ],
-    content: note.content,
-    editable: false,
-  });
-
-  useEffect(() => {
-    editor?.commands.setContent(note.content);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [note]);
 
   const handleClick = () => {
     if (!hasRightsToUpdateNote(note)) {
@@ -109,7 +89,12 @@ export const Note = ({
               overflow: "hidden",
             }}
           >
-            <EditorContent editor={editor} />
+            <Editor
+              content={note.content}
+              mode="read"
+              toolbar="none"
+              variant="ghost"
+            ></Editor>
           </div>
         </Card.Body>
         <Card.Footer>

--- a/frontend/src/features/note-modal/hooks/useNoteModal.ts
+++ b/frontend/src/features/note-modal/hooks/useNoteModal.ts
@@ -50,7 +50,7 @@ export const useNoteModal = (
     }
 
     const note: PickedNoteProps = {
-      content: editorRef.current?.getContent("plain") as string,
+      content: editorRef.current?.getContent("html") as string,
       color: colorValue,
       idwall: wallId,
       media: media,
@@ -81,7 +81,7 @@ export const useNoteModal = (
 
   const handleSaveNote = async () => {
     const note: PickedNoteProps = {
-      content: editorRef.current?.getContent("plain") as string,
+      content: editorRef.current?.getContent("html") as string,
       color: colorValue,
       idwall: loadedData.idwall as string,
       media: media || null,


### PR DESCRIPTION
In Note component use Editor from edifice-ui/editor to have all extensions to render properly notes from v1 app.

Save note content as HTML format to not lose content format information.