### PR TITLE
feat: #WB2-1587, add Close Confirm box to NoteModal edition

### DIFF
--- a/backend/src/main/resources/i18n/fr.json
+++ b/backend/src/main/resources/i18n/fr.json
@@ -42,6 +42,7 @@
   "collaborativewall.modal.title.edit": "Modification",
   "collaborativewall.modal.title.create": "Nouvelle Note",
   "collaborativewall.modal.note.content.placeholder": "Écrivez ici ce que vous voulez partager dans cette note.",
+  "collaborativewall.modal.note.confirm.close": "Les modifications que vous avez apportées ne seront pas enregistrées. Êtes-vous sur de vouloir continuer ?",
   "collaborativewall.note.notfound": "Note introuvable.",
   "collaborativewall.color.white": "Blanc",
   "collaborativewall.color.yellow": "Jaune",

--- a/frontend/src/features/note-modal/components/NoteModal.tsx
+++ b/frontend/src/features/note-modal/components/NoteModal.tsx
@@ -70,6 +70,7 @@ export const NoteModal = () => {
     handleNavigateToEditMode,
     handleSaveNote,
     handleCreateNote,
+    handleClose,
   } = useNoteModal(editorRef, colorValue, data, media);
 
   const { hasRightsToUpdateNote } = useAccess();
@@ -80,13 +81,13 @@ export const NoteModal = () => {
   return createPortal(
     <Modal
       id="UpdateNoteModal"
-      onModalClose={handleNavigateBack}
+      onModalClose={handleClose}
       size="md"
       isOpen={true}
       focusId=""
       scrollable={true}
     >
-      <Modal.Header onModalClose={handleNavigateBack}>
+      <Modal.Header onModalClose={handleClose}>
         {isReadMode && t("collaborativewall.modal.title.read", { ns: appCode })}
         {isEditMode && t("collaborativewall.modal.title.edit", { ns: appCode })}
         {isCreateMode &&


### PR DESCRIPTION
Add Close Confirm box to NoteModal edition:
- add react router `useBeforeUnload` hook to check if user is refreshing or leaving the page while editing a note
- add a check if user clicks outside the modal or clicks on the close icon while editing a note

It was complicated to put the MediaLibrary and Editor components inside a Form to check if user made some changes with the `isDirty` function, so I manually check values of edited note against loaded note values to check if user made some changes. In the future, it would be better to integrate complex input components into a Form, but in this case it requires some rewriting of Editor and MediaLibrary.

