### PR TITLE
fix: #WB2-1659, fix a11y cards Tab navigation

### DIFF
--- a/frontend/src/features/collaborative-wall/components/note.tsx
+++ b/frontend/src/features/collaborative-wall/components/note.tsx
@@ -21,6 +21,7 @@ export const Note = ({ data }: NodeProps) => {
   const editor = useEditor({
     extensions,
     content: data.note.content,
+    editable: false,
   });
 
   useEffect(() => {

--- a/frontend/src/features/collaborative-wall/wall.tsx
+++ b/frontend/src/features/collaborative-wall/wall.tsx
@@ -84,6 +84,7 @@ export const Wall = () => {
             zoomOnDoubleClick={false}
             panOnScroll={true}
             nodeDragThreshold={0}
+            nodesFocusable={false}
             onInit={onInit}
             onNodesChange={onNodesChange}
             onNodeClick={isOpenDropdown ? undefined : onNodeClick}

--- a/frontend/src/routes/collaborative-wall/index.css
+++ b/frontend/src/routes/collaborative-wall/index.css
@@ -176,13 +176,22 @@
   opacity: 1;
 }
 
-.card.is-selected{
+.card.is-selected {
   border-width: 3px;
   border-color: #ff8d2e;
 }
 
 .card.is-selected:hover {
   border-color: #ff8d2e;
+}
+
+.note:focus-within {
+  border: 2px solid #2a9cc8;
+  border-radius: 12px;
+}
+
+.card-container:focus-within .dropdown-note-action .dropdown .btn {
+  opacity: 1;
 }
 
 p.is-editor-empty:first-child::before {


### PR DESCRIPTION
Fix some a11y keyboard tab navigation issues:

- Remove ReactFlow node focus to prevent multiple focus on same Card when pressing tab
- Customize Card focus style to see it better
- Show Dropdown icon button when Card is focused