### PR TITLE
fix: #WB2-1695, fix note modal opening when clicking on Dropdown menu action

### DIFF
--- a/frontend/src/features/note-actions/index.tsx
+++ b/frontend/src/features/note-actions/index.tsx
@@ -22,11 +22,15 @@ export const NoteActions = ({ note }: { note: NoteProps }) => {
   const { hasRightsToUpdateNote } = useAccessStore();
   const { sendNoteDeletedEvent } = useWebsocketStore();
 
-  const handleEdit = () => {
+  const handleEdit = (event: React.MouseEvent) => {
+    event.stopPropagation();
+
     navigate(`note/${note._id}?mode=edit`);
   };
 
-  const handleDelete = async () => {
+  const handleDelete = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+
     await sendNoteDeletedEvent({
       _id: note._id,
       actionType: "Do",

--- a/frontend/src/features/note-modal/components/action-list.tsx
+++ b/frontend/src/features/note-modal/components/action-list.tsx
@@ -41,7 +41,7 @@ export const ActionList = ({
               !dropdownOption.hidden && (
                 <Dropdown.Item
                   icon={dropdownOption.icon}
-                  onClick={() => dropdownOption.action(null)}
+                  onClick={dropdownOption.action}
                 >
                   {dropdownOption.label}
                 </Dropdown.Item>


### PR DESCRIPTION
Fix note modal opening when clicking on Dropdown menu action.

Stop event propagation in Dropdown Action handlers to prevent Reactflow onNodeClick.